### PR TITLE
test: update league parameter in nextMatchesScraper call to 'mls'

### DIFF
--- a/tests/scraperOrchestrators.test.js
+++ b/tests/scraperOrchestrators.test.js
@@ -29,7 +29,7 @@ describe('scraperOrchestrators Integration Tests', () => {
             await writeFile(filePath, JSON.stringify(data, null, 2));
         };
 
-        await nextMatchesScraper(browser, 'liga-portugal', 'eu', mockCallback);
+        await nextMatchesScraper(browser, 'mls', 'eu', mockCallback);
 
         const files = await readdir(tempDir);
         expect(files.length).toBeGreaterThan(0);


### PR DESCRIPTION
This pull request updates the integration test for `scraperOrchestrators` to use a different league identifier. 

* **Test Update:**
  - Modified the `nextMatchesScraper` call in `scraperOrchestrators` integration tests to replace the league identifier `'liga-portugal'` with `'mls'`. (`tests/scraperOrchestrators.test.js`, [tests/scraperOrchestrators.test.jsL32-R32](diffhunk://#diff-72e3fba94c322d5cdfefb89dc63c98eb6224c9aabee9a386a49357922a19cd7bL32-R32))