### PR TITLE
chore: update publish workflow to include local CLI linking step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,27 +11,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        registry-url: 'https://registry.npmjs.org'
-        node-version: '20' # Specify your Node.js version
-        cache: 'npm'
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version: '20'
+          cache: 'npm'
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install  
 
-    - name: Run tests
-      run: npm test
+      - name: Link CLI locally
+        run: npm link
 
-    - name: Publish package
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      run: npm publish
+      - name: Run tests
+        run: npm test
 
-    - name: Notify success
-      if: success()
-      run: echo "Package published successfully!"
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: npm publish
+
+      - name: Notify success
+        if: success()
+        run: echo "Package published successfully!"


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yaml` file to enhance the Node.js setup process and include additional steps for testing and development. The most important changes include installing Playwright dependencies, linking the CLI locally, and adjusting the formatting for consistency.

Workflow updates:

* Added a step to install Playwright dependencies using `npx playwright install` after running `npm ci` to ensure the required browser binaries are available for testing.
* Introduced a new step to link the CLI locally with `npm link`, which facilitates local development and testing of the CLI.
* Adjusted the formatting of the `node-version` and `run` fields for consistency and readability.