### PR TITLE
feat: Add support for league 'allsvenskan'

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,7 +20,8 @@ const leaguesUrlsMap = {
     "bundesliga-2": { url: `${BASE_URL}/football/germany/2-bundesliga`, fixedStructure: false },
     "argentina": { url: `${BASE_URL}/football/argentina/liga-profesional`, fixedStructure: false },
     "champions-league": { url: `${BASE_URL}/football/europe/champions-league`, fixedStructure: false },
-    "europa-league": { url: `${BASE_URL}/football/europe/europa-league`, fixedStructure: false }
+    "europa-league": { url: `${BASE_URL}/football/europe/europa-league`, fixedStructure: false },
+    "allsvenskan": { url: `${BASE_URL}/football/sweden/allsvenskan`, fixedStructure: true }
 };
 
 const oddsFormatMap = {


### PR DESCRIPTION
Allsvenskan is the top Swedish football (soccer) league. Would be nice if odds-portal-scraper could support that.

A single line is added to 'leaguesUrlsMap', pretty self explanatory. 
