### PR TITLE
Bugfix/under over

### DIFF
--- a/lib/scrapers.js
+++ b/lib/scrapers.js
@@ -157,6 +157,8 @@ async function extractOverUnderOdds(page, underOver) {
         "1.5": "Over/Under +1.5",
         "3.5": "Over/Under +3.5"
     }
+
+    const wanted = `+${underOver}`;
     logger.info(`scrapping odd for under/over ${underOver} market`)
     const marketUlSelector = 'ul.visible-links.bg-black-main.odds-tabs > li'
     await page.waitForSelector(marketUlSelector)
@@ -170,28 +172,44 @@ async function extractOverUnderOdds(page, underOver) {
     // Click the specific Over/Under market (e.g., +2.5)
     await page.locator(specificMarketSelector).filter({ hasText: mapping[underOver] }).click();
 
+    await page.waitForSelector('div[data-testid="odd-container"] p.odds-text');
 
-    const rowDataSelector = 'div.border-black-borders.flex.h-9.border-b.border-l.border-r.text-xs.bg-gray-med_light.border-black-borders.border-b';
-    await page.waitForSelector(rowDataSelector);
+    const rowsSelector = 'div[data-testid="over-under-expanded-row"]';
 
-    const data = await page.locator(rowDataSelector).evaluateAll(rows => {
-        return rows.map(row => {
-            const bookmakerNameElement = row.querySelector('a > p');
-            const bookmakerName = bookmakerNameElement ? bookmakerNameElement.textContent.trim() : 'Unknown';
 
-            const oddsElements = row.querySelectorAll('div.flex-center.font-bold > div > p');
-            const oddsOver = oddsElements.length > 0 ? oddsElements[0].textContent.trim() : 'N/A';
-            const oddsUnder = oddsElements.length > 1 ? oddsElements[1].textContent.trim() : 'N/A';
+    const rows = await page.$$eval(rowsSelector, (rows, wanted) => {
+        const clean = s => (s || '').replace(/\s+/g, ' ').trim();
 
-            if (bookmakerName !== 'Unknown' && oddsOver !== 'N/A' && oddsUnder !== 'N/A') {
-                return { bookmakerName, oddsOver, oddsUnder };
-            }
-            return null; // Return null for rows that don't meet criteria
-        }).filter(item => item !== null); // Filter out null items
-    });
+        return rows
+            // keep only rows matching the desired total (either via text or attribute)
+            .filter(row => {
+                const totalEl = row.querySelector('div[data-testid="total-container"]');
+                const totalText = totalEl ? clean(totalEl.textContent) : null;
+                const attr = row.querySelector('[provider-name]')?.getAttribute('provider-name');
+                return totalText === wanted || attr === wanted;
+            })
+            .map(row => {
+                const bookie = clean(
+                    row.querySelector('p[data-testid="outrights-expanded-bookmaker-name"]')?.textContent
+                );
 
-    return data
-};
+                const oddsContainers = row.querySelectorAll('div[data-testid="odd-container"]');
+
+                const takeText = el => clean(
+                    (el.querySelector('a.odds-link') || el.querySelector('p.odds-text'))?.textContent
+                );
+
+                const oddsOver = oddsContainers[0] ? takeText(oddsContainers[0]) : null;
+                const oddsUnder = oddsContainers[1] ? takeText(oddsContainers[1]) : null;
+
+                return bookie && oddsOver && oddsUnder
+                    ? { bookmakerName: bookie, oddsOver, oddsUnder }
+                    : null;
+            })
+            .filter(Boolean);
+    }, wanted);
+    return rows;
+}
 
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "odds-portal-scraper",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "odds-portal-scraper",
-      "version": "2.10.2",
+      "version": "2.10.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odds-portal-scraper",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "odds portal scraper",
   "main": "index.js",
   "bin": {

--- a/tests/scraperOrchestrators.test.js
+++ b/tests/scraperOrchestrators.test.js
@@ -29,7 +29,7 @@ describe('scraperOrchestrators Integration Tests', () => {
             await writeFile(filePath, JSON.stringify(data, null, 2));
         };
 
-        await nextMatchesScraper(browser, 'mls', 'eu', mockCallback);
+        await nextMatchesScraper(browser, 'champions-league', 'eu', mockCallback);
 
         const files = await readdir(tempDir);
         expect(files.length).toBeGreaterThan(0);


### PR DESCRIPTION
This pull request updates the odds extraction logic for Over/Under markets in the scraper, improves the accuracy of data collection, and bumps the package version. The main changes focus on refining how odds are scraped and filtered, ensuring that only relevant rows are processed, and updating integration tests to use a different league.

**Odds extraction improvements:**

* Refactored the `extractOverUnderOdds` function in `lib/scrapers.js` to filter and map rows based on the desired Over/Under market, using more precise selectors and text matching for odds and bookmaker names. This ensures only relevant odds are collected and improves data reliability. [[1]](diffhunk://#diff-8ad532489753994da40f1e13c0c5685a3ef7c816bcc8424039a441882cf8ccd5R160-R161) [[2]](diffhunk://#diff-8ad532489753994da40f1e13c0c5685a3ef7c816bcc8424039a441882cf8ccd5R175-R212)

**Testing updates:**

* Updated the integration test in `tests/scraperOrchestrators.test.js` to use the 'champions-league' league instead of 'mls', ensuring broader test coverage.

**Version bump:**

* Increased the package version from `2.10.2` to `2.10.3` in `package.json` to reflect the new changes.